### PR TITLE
Corrected a typo and added a margin for the header icon in style.css

### DIFF
--- a/styles/style.css
+++ b/styles/style.css
@@ -38,7 +38,7 @@ p, li {
     font-size: 1.5rem;
 }
 nav span, nav a {
-    font-size: 2 rem;
+    font-size: 2rem;
 }
 header img {
     height: 60px;
@@ -64,6 +64,7 @@ h1 {
 header img {
     display: block;
     align-self: center;
+    margin: 2%;
 }
 
 nav {


### PR DESCRIPTION
One of the font-size attributes (for span/a elements that were a children of the nav element) had a space inappropriately placed between the value and the unit.

Added a margin for the icon in the header so that it wasn't pushing against the side of the page.